### PR TITLE
Rebuild version 0.10.1 for python 3.12 and 3.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,8 +46,8 @@ test:
     - pyproject.toml
   commands:
     - pip check
-    - pytest --pyargs composeml -v {{ ignore_tests_featuretools }} {{ ignore_tests | join(" ")}} # [py<312]
-    - pytest --pyargs composeml -v {{ ignore_tests | join(" ")}} # [py>311]
+    - pytest --pyargs composeml -v {{ ignore_tests | join(" ")}} # [py<312]
+    - pytest --pyargs composeml -v {{ ignore_tests | join(" ")}} {{ ignore_tests_featuretools }} # [py>311]
   imports:
     - composeml
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,16 @@
 {% set version = "0.10.1" %}
+{% set name = "composeml" %}
 
 package:
-  name: composeml
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/c/composeml/composeml-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: d87fc181be72fadec16ea0e44ebd363b4e2e3620c87c8b2cae6e236fd00761d4
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<38 or s390x]
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation -vv .
 
@@ -26,19 +27,24 @@ requirements:
     - matplotlib-base >=3.3.3
     - seaborn >=0.11.0
 
+{% set ignore_tests = [
+  "--ignore=composeml/tests/test_featuretools.py"
+]%}
 test:
+  source_files:
+    - composeml
+    - pyproject.toml
   commands:
     - pip check
-    #skip failing tests connected with underlaying pandas issues eg  pandas._libs.tslibs.np_datetime.OutOfBoundsDatetime: Cannot cast 0001-01-01 02:00:00 to unit='ns' without overflow.
-    - pytest --pyargs composeml -v -k "not ( test_search_offset_mix_5 or test_minimum_data_per_group[minimum_data1] or test_sorted_distribution or test_subscriptable_slices[True-offsets2] or test_subscriptable_slices[True-offsets3])"
+    - pytest --pyargs composeml -v {{ ignore_tests }} # [py<312]
   imports:
     - composeml
   requires:
     - pip
     - pytest >=7.1.2
     - pytest-xdist >=2.5.0
-    - featuretools >=1.27.0
-    - woodwork >=0.11.0
+    - featuretools >=1.27.0  # [py<312]
+    - woodwork >=0.11.0 # [py<313]
     - pyarrow >=3.0.0
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,16 +27,27 @@ requirements:
     - matplotlib-base >=3.3.3
     - seaborn >=0.11.0
 
-{% set ignore_tests = [
+{% set ignore_tests_featuretools = [
   "--ignore=composeml/tests/test_featuretools.py"
 ]%}
+# Assertion errors
+{% set ignore_tests = [
+  "--deselect=composeml/tests/test_data_slice/test_extension.py::test_subscriptable_slices[True-offsets2]",
+  "--deselect=composeml/tests/test_data_slice/test_extension.py::test_subscriptable_slices[True-offsets3]",
+  "--deselect=composeml/tests/test_featuretools.py::test_dfs",
+  "--deselect=composeml/tests/test_label_maker.py::test_search_offset_mix_5",
+  "--deselect=composeml/tests/test_label_maker.py::test_minimum_data_per_group[minimum_data1]",
+  "--deselect=composeml/tests/test_label_times.py::test_sorted_distribution"
+]%}
+
 test:
   source_files:
     - composeml
     - pyproject.toml
   commands:
     - pip check
-    - pytest --pyargs composeml -v {{ ignore_tests }} # [py<312]
+    - pytest --pyargs composeml -v {{ ignore_tests_featuretools }} {{ ignore_tests | join(" ")}} # [py<312]
+    - pytest --pyargs composeml -v {{ ignore_tests | join(" ")}} # [py>311]
   imports:
     - composeml
   requires:
@@ -46,7 +57,6 @@ test:
     - featuretools >=1.27.0  # [py<312]
     - woodwork >=0.11.0 # [py<313]
     - pyarrow >=3.0.0
-
 
 about:
   doc_url: https://compose.alteryx.com/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: d87fc181be72fadec16ea0e44ebd363b4e2e3620c87c8b2cae6e236fd00761d4
 
 build:
@@ -44,10 +44,15 @@ test:
     - pyproject.toml
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert version('{{ name }}') == '{{ version }}'"
     - pytest --pyargs composeml -v {{ ignore_tests | join(" ")}} # [py<312]
     - pytest --pyargs composeml -v {{ ignore_tests | join(" ")}} {{ ignore_tests_featuretools }} # [py>311]
   imports:
     - composeml
+    - composeml.data_slice
+    - composeml.label_search
+    - composeml.label_times
+    - composeml.tests
   requires:
     - pip
     - pytest >=7.1.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,9 +27,7 @@ requirements:
     - matplotlib-base >=3.3.3
     - seaborn >=0.11.0
 
-{% set ignore_tests_featuretools = [
-  "--ignore=composeml/tests/test_featuretools.py"
-]%}
+{% set ignore_tests_featuretools = "--ignore=composeml/tests/test_featuretools.py" %}
 # Assertion errors
 {% set ignore_tests = [
   "--deselect=composeml/tests/test_data_slice/test_extension.py::test_subscriptable_slices[True-offsets2]",


### PR DESCRIPTION
composeml 0.10.1 

**Destination channel:** main

### Links

- [PKG-10264]
- dev_url:        https://github.com/alteryx/compose/tree/v0.10.1
- conda_forge:    https://github.com/conda-forge/composeml-feedstock
- pypi:           https://pypi.org/project/composeml/0.10.1
- pypi inspector: https://inspector.pypi.io/project/composeml/0.10.1

### Explanation of changes:

- rebuild for new versions of python

[PKG-10264]: https://anaconda.atlassian.net/browse/PKG-10264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ